### PR TITLE
Add optional debugging and docs

### DIFF
--- a/deploy/releases/README.md
+++ b/deploy/releases/README.md
@@ -72,3 +72,13 @@ You can apply the rest of the CCM by running:
 ```bash
 kubectl apply -f v0.0.4/deployment.yaml
 ```
+
+### Logging
+
+By default, ccm does minimal logging, relying on the supporting infrastructure from kubernetes. However, it does support
+optional additional logging levels via the `--v=<level>` flag. In general:
+
+* `--v=2`: log most function calls for devices and facilities, when relevant logging the returned values
+* `--v=3`: log additional data when logging returned values, usually entire go structs
+* `--v=5`: log every function call, including those called very frequently
+

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/cloud-provider v0.0.0
 	k8s.io/component-base v0.0.0
+	k8s.io/klog v0.3.1
 	k8s.io/kubernetes v1.15.0
 )
 

--- a/packet/cloud.go
+++ b/packet/cloud.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 )
 
 const (
@@ -60,40 +61,48 @@ func init() {
 // Initialize provides the cloud with a kubernetes client builder and may spawn goroutines
 // to perform housekeeping activities within the cloud provider.
 func (c *cloud) Initialize(_ cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+	klog.V(5).Info("called Initialize")
 }
 
 // LoadBalancer returns a balancer interface. Also returns true if the interface is supported, false otherwise.
 // TODO unimplemented
 func (c *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	klog.V(5).Info("called LoadBalancer")
 	return nil, false
 }
 
 // Instances returns an instances interface. Also returns true if the interface is supported, false otherwise.
 func (c *cloud) Instances() (cloudprovider.Instances, bool) {
+	klog.V(5).Info("called Instances")
 	return c.instances, true
 }
 
 // Zones returns a zones interface. Also returns true if the interface is supported, false otherwise.
 func (c *cloud) Zones() (cloudprovider.Zones, bool) {
+	klog.V(5).Info("called Zones")
 	return c.zones, true
 }
 
 // Clusters returns a clusters interface.  Also returns true if the interface is supported, false otherwise.
 func (c *cloud) Clusters() (cloudprovider.Clusters, bool) {
+	klog.V(5).Info("called Clusters")
 	return nil, false
 }
 
 // Routes returns a routes interface along with whether the interface is supported.
 func (c *cloud) Routes() (cloudprovider.Routes, bool) {
+	klog.V(5).Info("called Routes")
 	return nil, false
 }
 
 // ProviderName returns the cloud provider ID.
 func (c *cloud) ProviderName() string {
+	klog.V(2).Infof("called ProviderName, returning %s", providerName)
 	return providerName
 }
 
 // HasClusterID returns true if a ClusterID is required and set
 func (c *cloud) HasClusterID() bool {
+	klog.V(5).Info("called HasClusterID")
 	return false
 }

--- a/packet/devices.go
+++ b/packet/devices.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 )
 
 type instances struct {
@@ -24,6 +25,7 @@ func newInstances(client *packngo.Client, projectID string) cloudprovider.Instan
 
 // NodeAddresses returns the addresses of the specified instance.
 func (i *instances) NodeAddresses(_ context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
+	klog.V(2).Infof("called NodeAddresses with node name %s", name)
 	device, err := deviceByName(i.client, i.project, name)
 	if err != nil {
 		return nil, err
@@ -38,6 +40,7 @@ func (i *instances) NodeAddresses(_ context.Context, name types.NodeName) ([]v1.
 // from the node whose nodeaddresses are being queried. i.e. local metadata
 // services cannot be used in this method to obtain nodeaddresses
 func (i *instances) NodeAddressesByProviderID(_ context.Context, providerID string) ([]v1.NodeAddress, error) {
+	klog.V(2).Infof("called NodeAddressesByProviderID with providerID %s", providerID)
 	device, err := i.deviceFromProviderID(providerID)
 	if err != nil {
 		return nil, err
@@ -77,16 +80,19 @@ func nodeAddresses(device *packngo.Device) ([]v1.NodeAddress, error) {
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.
 // Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
 func (i *instances) InstanceID(_ context.Context, nodeName types.NodeName) (string, error) {
+	klog.V(2).Infof("called InstanceID with node name %s", nodeName)
 	device, err := deviceByName(i.client, i.project, nodeName)
 	if err != nil {
 		return "", err
 	}
 
+	klog.V(2).Infof("InstanceID for %s: %s", nodeName, device.ID)
 	return device.ID, nil
 }
 
 // InstanceType returns the type of the specified instance.
 func (i *instances) InstanceType(_ context.Context, nodeName types.NodeName) (string, error) {
+	klog.V(2).Infof("called InstanceType with node name %s", nodeName)
 	device, err := deviceByName(i.client, i.project, nodeName)
 	if err != nil {
 		return "", err
@@ -97,6 +103,7 @@ func (i *instances) InstanceType(_ context.Context, nodeName types.NodeName) (st
 
 // InstanceTypeByProviderID returns the type of the specified instance.
 func (i *instances) InstanceTypeByProviderID(_ context.Context, providerID string) (string, error) {
+	klog.V(2).Infof("called InstanceTypeByProviderID with providerID %s", providerID)
 	device, err := i.deviceFromProviderID(providerID)
 	if err != nil {
 		return "", err
@@ -108,18 +115,21 @@ func (i *instances) InstanceTypeByProviderID(_ context.Context, providerID strin
 // AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
 // expected format for the key is standard ssh-keygen format: <protocol> <blob>
 func (i *instances) AddSSHKeyToAllInstances(_ context.Context, user string, keyData []byte) error {
+	klog.V(2).Info("called AddSSHKeyToAllInstances")
 	return cloudprovider.NotImplemented
 }
 
 // CurrentNodeName returns the name of the node we are currently running on
 // On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
 func (i *instances) CurrentNodeName(_ context.Context, nodeName string) (types.NodeName, error) {
+	klog.V(2).Infof("called CurrentNodeName with nodeName %s", nodeName)
 	return types.NodeName(nodeName), nil
 }
 
 // InstanceExistsByProviderID returns true if the instance for the given provider id still is running.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 func (i *instances) InstanceExistsByProviderID(_ context.Context, providerID string) (bool, error) {
+	klog.V(2).Infof("called InstanceExistsByProviderID with providerID %s", providerID)
 	_, err := i.deviceFromProviderID(providerID)
 	switch {
 	case err != nil && err == cloudprovider.InstanceNotFound:
@@ -133,6 +143,7 @@ func (i *instances) InstanceExistsByProviderID(_ context.Context, providerID str
 
 // InstanceShutdownByProviderID returns true if the instance is shutdown in cloudprovider
 func (i *instances) InstanceShutdownByProviderID(_ context.Context, providerID string) (bool, error) {
+	klog.V(2).Infof("called InstanceShutdownByProviderID with providerID %s", providerID)
 	device, err := i.deviceFromProviderID(providerID)
 	if err != nil {
 		return false, err
@@ -142,6 +153,7 @@ func (i *instances) InstanceShutdownByProviderID(_ context.Context, providerID s
 }
 
 func deviceByID(client *packngo.Client, id string) (*packngo.Device, error) {
+	klog.V(2).Infof("called deviceByID with ID %s", id)
 	device, _, err := client.Devices.Get(id, nil)
 	if isNotFound(err) {
 		return nil, cloudprovider.InstanceNotFound
@@ -151,6 +163,7 @@ func deviceByID(client *packngo.Client, id string) (*packngo.Device, error) {
 
 // deviceByName returns an instance thats hostname matches the kubernetes node.Name
 func deviceByName(client *packngo.Client, projectID string, nodeName types.NodeName) (*packngo.Device, error) {
+	klog.V(2).Infof("called deviceByName with projectID %s nodeName %s", projectID, nodeName)
 	if string(nodeName) == "" {
 		return nil, errors.New("node name cannot be empty string")
 	}
@@ -161,6 +174,8 @@ func deviceByName(client *packngo.Client, projectID string, nodeName types.NodeN
 
 	for _, device := range devices {
 		if device.Hostname == string(nodeName) {
+			klog.V(2).Infof("Found device for nodeName %s", nodeName)
+			klog.V(3).Infof("%#v", device)
 			return &device, nil
 		}
 	}
@@ -173,6 +188,7 @@ func deviceByName(client *packngo.Client, projectID string, nodeName types.NodeN
 // The providerID spec should be retrievable from the Kubernetes
 // node object. The expected format is: packet://device-id
 func deviceIDFromProviderID(providerID string) (string, error) {
+	klog.V(2).Infof("called deviceIDFromProviderID with providerID %s", providerID)
 	if providerID == "" {
 		return "", errors.New("providerID cannot be empty string")
 	}
@@ -191,6 +207,7 @@ func deviceIDFromProviderID(providerID string) (string, error) {
 
 // deviceFromProviderID uses providerID to get the device id and return the device
 func (i *instances) deviceFromProviderID(providerID string) (*packngo.Device, error) {
+	klog.V(2).Infof("called deviceFromProviderID with providerID %s", providerID)
 	id, err := deviceIDFromProviderID(providerID)
 	if err != nil {
 		return nil, err

--- a/packet/facilities.go
+++ b/packet/facilities.go
@@ -6,6 +6,7 @@ import (
 	"github.com/packethost/packngo"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 )
 
 type zones struct {
@@ -22,6 +23,7 @@ func newZones(client *packngo.Client, projectID string) cloudprovider.Zones {
 // For the case of external cloud providers, use GetZoneByProviderID or GetZoneByNodeName since GetZone
 // can no longer be called from the kubelets.
 func (z zones) GetZone(_ context.Context) (cloudprovider.Zone, error) {
+	klog.V(2).Info("called GetZones")
 	return cloudprovider.Zone{}, cloudprovider.NotImplemented
 }
 
@@ -29,6 +31,7 @@ func (z zones) GetZone(_ context.Context) (cloudprovider.Zone, error) {
 // This method is particularly used in the context of external cloud providers where node initialization must be down
 // outside the kubelets.
 func (z zones) GetZoneByProviderID(_ context.Context, providerID string) (cloudprovider.Zone, error) {
+	klog.V(2).Infof("called GetZoneByProviderID with providerID %s", providerID)
 	id, err := deviceIDFromProviderID(providerID)
 	if err != nil {
 		return cloudprovider.Zone{}, err
@@ -46,6 +49,7 @@ func (z zones) GetZoneByProviderID(_ context.Context, providerID string) (cloudp
 // This method is particularly used in the context of external cloud providers where node initialization must be down
 // outside the kubelets.
 func (z zones) GetZoneByNodeName(_ context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
+	klog.V(2).Infof("called GetZoneByNodeName with nodeName %s", nodeName)
 	device, err := deviceByName(z.client, z.project, nodeName)
 	if err != nil {
 		return cloudprovider.Zone{}, err


### PR DESCRIPTION
Adds some debugging options, which remain off by default, but are enabled by `--v=<level>`, plus docs for how to use it.