### PR TITLE
Support secrets from file to align with CSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ metadata:
   name: packet-cloud-config
   namespace: kube-system
 stringData:
-  apiKey: "abc123abc123abc123"
-  projectID: "abc123abc123abc123"
+  cloud-sa.json: |
+    {
+    "apiKey": "abc123abc123abc123"
+    "projectID": "abc123abc123abc123"
+    }  
 ```
 
 Then apply the file via `kubectl`, e.g.:

--- a/deploy/releases/v1.0.0/deployment.yaml
+++ b/deploy/releases/v1.0.0/deployment.yaml
@@ -41,21 +41,20 @@ spec:
           - "--leader-elect=false"
           - "--allow-untagged-cloud=true"
           - "--authentication-skip-lookup=true"
+          - "--provider-config=/etc/cloud-sa/cloud-sa.json"
         resources:
           requests:
             cpu: 100m
             memory: 50Mi
-        env:
-          - name: PACKET_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: packet-cloud-config
-                key: apiKey
-          - name: PACKET_PROJECT_ID
-            valueFrom:
-              secretKeyRef:
-                name: packet-cloud-config
-                key: projectID
+        volumeMounts:
+          - name: cloud-sa-volume
+            readOnly: true
+            mountPath: "/etc/cloud-sa"
+      volumes:
+        - name: cloud-sa-volume
+          secret:
+            secretName: packet-cloud-config
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/template/secret.yaml
+++ b/deploy/template/secret.yaml
@@ -4,5 +4,8 @@ metadata:
   name: packet-cloud-config
   namespace: kube-system
 stringData:
-  apiKey: "packet auth token"
-  projectID: "packet project id"
+  cloud-sa.json: |
+    {
+    "apiKey": "packet auth token",
+    "projectID": "packet project id"
+    }

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	goflag "flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"time"
@@ -13,8 +15,17 @@ import (
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 
-	_ "github.com/packethost/packet-ccm/packet"
+	"github.com/packethost/packet-ccm/packet"
 	"github.com/spf13/pflag"
+)
+
+const (
+	apiKeyName    = "PACKET_API_KEY"
+	projectIDName = "PACKET_PROJECT_ID"
+)
+
+var (
+	providerConfig string
 )
 
 func main() {
@@ -25,11 +36,66 @@ func main() {
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
+	// add our config
+	command.PersistentFlags().StringVar(&providerConfig, "provider-config", "", "path to provider config file")
+
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	// parse our flags so we get the providerConfig
+	command.ParseFlags(os.Args[1:])
+
+	// register the provider
+	config, err := getPacketConfig(providerConfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "provider config error: %v\n", err)
+		os.Exit(1)
+	}
+	// register the provider
+	if err := packet.InitializeProvider(config); err != nil {
+		fmt.Fprintf(os.Stderr, "provider initialization error: %v\n", err)
+		os.Exit(1)
+	}
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func getPacketConfig(providerConfig string) (packet.Config, error) {
+	// get our token and project
+	var config, rawConfig packet.Config
+	if providerConfig != "" {
+		configBytes, err := ioutil.ReadFile(providerConfig)
+		if err != nil {
+			return config, fmt.Errorf("failed to get read configuration file at path %s: %v", providerConfig, err)
+		}
+		err = json.Unmarshal(configBytes, &rawConfig)
+		if err != nil {
+			return config, fmt.Errorf("failed to process json of configuration file at path %s: %v", providerConfig, err)
+		}
+	}
+
+	// read env vars; if not set, use rawConfig
+	apiToken := os.Getenv(apiKeyName)
+	if apiToken == "" {
+		apiToken = rawConfig.AuthToken
+	}
+	config.AuthToken = apiToken
+
+	projectID := os.Getenv(projectIDName)
+	if projectID == "" {
+		projectID = rawConfig.ProjectID
+	}
+	config.ProjectID = projectID
+
+	if apiToken == "" {
+		return config, fmt.Errorf("environment variable %q is required", apiKeyName)
+	}
+
+	if projectID == "" {
+		return config, fmt.Errorf("environment variable %q is required", projectIDName)
+	}
+	return config, nil
 }

--- a/packet/cloud_test.go
+++ b/packet/cloud_test.go
@@ -61,7 +61,7 @@ func testGetValidCloud(t *testing.T) (*cloud, *store.Memory) {
 	client := constructClient(token, &urlString)
 
 	// now just need to create a client
-	c, _ := newCloud(nil, token, projectID, client)
+	c, _ := newCloud(nil, projectID, client)
 	validCloud = c.(*cloud)
 	return validCloud, backend
 }


### PR DESCRIPTION
Fixes #22 

**Do not merge until [WIP] is removed.**

This is a first run. There still are some changes to be made, but they depend on #31 being merged first. I will remove `[WIP]` and comment that it is ready, when you can merge it in.

This PR aligns secrets with how [csi-packet](https://github.com/packethost/csi-packet) does it, allowing a single secret to serve both. It will be our standard going forward.

When this is done, the api key and project ID can be in one of either of the following two places (aligned with CSI):

* env vars, as per the current implementation
* a secrets file in json structure

Eventually, we will allow it to dynamically monitor the secrets file and update if it changes.

What is left to complete this:

- [x] Merge #31 and rebase off of it
- [x] Update `template/secret.yaml` to reflect the new design
- [x] Update documentation to describe the new design
- [x] Test again on a live cluster

