### PR TITLE
README.md: add missing comma to secret example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ metadata:
 stringData:
   cloud-sa.json: |
     {
-    "apiKey": "abc123abc123abc123"
+    "apiKey": "abc123abc123abc123",
     "projectID": "abc123abc123abc123"
     }  
 ```


### PR DESCRIPTION
If secret was copied as-is, without comma, Packet CCM would be stuck
in a crash loop:

provider config error: failed to process json of configuration file at
path /etc/cloud-sa/cloud-sa.json: invalid character '"' after object
key:value pair

Signed-off-by: Martin Polednik <m.polednik@gmail.com>