### PR TITLE
add bgp annotations to nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	4d63.com/gochecknoglobals v0.0.0-20190306162314-7c3491d2b6ec // indirect
 	4d63.com/gochecknoinits v0.0.0-20200108094044-eb73b47b9fc4 // indirect
+	github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214 // indirect
 	github.com/alexkohler/nakedret v1.0.0 // indirect
 	github.com/hashicorp/go-hclog v0.12.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.4
@@ -17,6 +18,8 @@ require (
 	github.com/pallinder/go-randomdata v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stripe/safesql v0.2.0 // indirect
+	github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214 h1:YI/8G3uLbYyowJeOPVL6BMKe2wbL54h0FdEKmncU6lU=
+github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214/go.mod h1:Ef5UOtJdJ5rVFObdOVsrNgKV/Wf4I+daTCSk8GTrHIk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexkohler/nakedret v1.0.0 h1:S/bzOFhZHYUJp6qPmdXdFHS5nlWGFmLmoc8QOydvotE=
@@ -634,6 +636,8 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stripe/safesql v0.2.0 h1:xiefmCDd8c35PVSGrL2FhBiaKxviXnGziBDOpOejeBE=
+github.com/stripe/safesql v0.2.0/go.mod h1:q7b2n0JmzM1mVGfcYpanfVb2j23cXZeWFxcILPn3JV4=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
@@ -641,6 +645,8 @@ github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLY
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 h1:vY5WqiEon0ZSTGM3ayVVi+twaHKHDFUVloaQ/wug9/c=
+github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9/go.mod h1:q+QjxYvZ+fpjMXqs+XEriussHjSYqeXVnAdSV1tkMYk=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ultraware/funlen v0.0.1/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strconv"
 	"time"
 
 	cliflag "k8s.io/component-base/cli/flag"
@@ -20,10 +21,15 @@ import (
 )
 
 const (
-	apiKeyName              = "PACKET_API_KEY"
-	projectIDName           = "PACKET_PROJECT_ID"
-	facilityName            = "PACKET_FACILITY_NAME"
-	disableLoadBalancerName = "PACKET_DISABLE_LB"
+	apiKeyName               = "PACKET_API_KEY"
+	projectIDName            = "PACKET_PROJECT_ID"
+	facilityName             = "PACKET_FACILITY_NAME"
+	disableLoadBalancerName  = "PACKET_DISABLE_LB"
+	envVarLocalASN           = "PACKET_LOCAL_ASN"
+	envVarPeerASN            = "PACKET_PEER_ASN"
+	envVarAnnotationLocalASN = "PACKET_ANNOTATION_LOCAL_ASN"
+	envVarAnnotationPeerASNs = "PACKET_ANNOTATION_PEER_ASNS"
+	envVarAnnotationPeerIPs  = "PACKET_ANNOTATION_PEER_IPS"
 	// fixedDisableLoadBalancers disabled until the packet API is ready with IP management
 	fixedDisableLoadBalancers = true
 )
@@ -133,6 +139,53 @@ func getPacketConfig(providerConfig, loadBalancerManifestPath string) (packet.Co
 		facility = metadata.Facility
 	}
 	config.Facility = facility
+
+	// get the local ASN
+	localASN := os.Getenv(envVarLocalASN)
+	switch {
+	case localASN != "":
+		localASNNo, err := strconv.Atoi(localASN)
+		if err != nil {
+			return config, fmt.Errorf("env var %s must be a number, was %s: %v", envVarLocalASN, localASN, err)
+		}
+		config.LocalASN = localASNNo
+	case rawConfig.LocalASN != 0:
+		config.LocalASN = rawConfig.LocalASN
+	default:
+		config.LocalASN = packet.DefaultLocalASN
+	}
+
+	// get the peer ASN
+	peerASN := os.Getenv(envVarPeerASN)
+	switch {
+	case peerASN != "":
+		peerASNNo, err := strconv.Atoi(peerASN)
+		if err != nil {
+			return config, fmt.Errorf("env var %s must be a number, was %s: %v", envVarPeerASN, peerASN, err)
+		}
+		config.PeerASN = peerASNNo
+	case rawConfig.PeerASN != 0:
+		config.PeerASN = rawConfig.PeerASN
+	default:
+		config.PeerASN = packet.DefaultPeerASN
+	}
+
+	// set the annotations
+	config.AnnotationLocalASN = packet.DefaultAnnotationNodeASN
+	annotationLocalASN := os.Getenv(envVarAnnotationLocalASN)
+	if annotationLocalASN != "" {
+		config.AnnotationLocalASN = annotationLocalASN
+	}
+	config.AnnotationPeerASNs = packet.DefaultAnnotationPeerASNs
+	annotationPeerASNs := os.Getenv(envVarAnnotationPeerASNs)
+	if annotationPeerASNs != "" {
+		config.AnnotationPeerASNs = annotationPeerASNs
+	}
+	config.AnnotationPeerIPs = packet.DefaultAnnotationPeerIPs
+	annotationPeerIPs := os.Getenv(envVarAnnotationPeerIPs)
+	if annotationPeerIPs != "" {
+		config.AnnotationPeerIPs = annotationPeerIPs
+	}
 
 	return config, nil
 }

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -1,24 +1,36 @@
 package packet
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/packethost/packngo"
+	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
 
 type bgp struct {
-	project string
-	client  *packngo.Client
+	project                                                   string
+	client                                                    *packngo.Client
+	k8sclient                                                 kubernetes.Interface
+	peerASN, localASN                                         int
+	annotationLocalASN, annotationPeerASNs, annotationPeerIPs string
 }
 
-func newBGP(client *packngo.Client, project string) *bgp {
+func newBGP(client *packngo.Client, project string, localASN, peerASN int, annotationLocalASN, annotationPeerASNs, annotationPeerIPs string) *bgp {
 	return &bgp{
-		project: project,
-		client:  client,
+		project:            project,
+		client:             client,
+		localASN:           localASN,
+		peerASN:            peerASN,
+		annotationLocalASN: annotationLocalASN,
+		annotationPeerASNs: annotationPeerASNs,
+		annotationPeerIPs:  annotationPeerIPs,
 	}
 }
 
@@ -26,6 +38,7 @@ func (b *bgp) name() string {
 	return "bgp"
 }
 func (b *bgp) init(k8sclient kubernetes.Interface) error {
+	b.k8sclient = k8sclient
 	// enable BGP
 	klog.V(2).Info("bgp.init(): enabling BGP on project")
 	if err := b.enableBGP(); err != nil {
@@ -42,6 +55,7 @@ func (b *bgp) serviceReconciler() serviceReconciler {
 }
 
 func (b *bgp) reconcileNodes(nodes []*v1.Node, remove bool) error {
+	klog.V(2).Infof("bgp.reconcileNodes(): called for nodes %v", nodes)
 	for _, node := range nodes {
 		// are we adding or removing the node?
 		if !remove {
@@ -56,15 +70,63 @@ func (b *bgp) reconcileNodes(nodes []*v1.Node, remove bool) error {
 				klog.Errorf("could not ensure BGP enabled for node %s: %v", node.Name, err)
 			}
 			klog.V(2).Infof("bgp.reconcileNodes(): bgp enabled on node %s", node.Name)
+
+			// add annotations for bgp
+			klog.V(2).Infof("bgp.reconcileNodes(): setting annotations on node %s", node.Name)
+			// get the bgp info
+			peerAddress, err := getNodePeerAddress(id, b.client)
+			if err != nil {
+				klog.Errorf("bgp.reconcileNodes(): could not get BGP info for node %s: %v", node.Name, err)
+			} else {
+				localASN := strconv.Itoa(b.localASN)
+				peerASNs := strconv.Itoa(b.peerASN)
+				newAnnotations := make(map[string]string)
+				oldAnnotations := node.Annotations
+				if oldAnnotations == nil {
+					oldAnnotations = make(map[string]string)
+				}
+				val, ok := oldAnnotations[b.annotationLocalASN]
+				if !ok || val != localASN {
+					newAnnotations[b.annotationLocalASN] = localASN
+				}
+
+				val, ok = oldAnnotations[b.annotationPeerASNs]
+				if !ok || val != peerASNs {
+					newAnnotations[b.annotationPeerASNs] = peerASNs
+				}
+
+				val, ok = oldAnnotations[b.annotationPeerIPs]
+				if !ok || val != peerAddress {
+					newAnnotations[b.annotationPeerIPs] = peerAddress
+				}
+
+				// patch the node with the new annotations
+				if len(newAnnotations) > 0 {
+					mergePatch, _ := json.Marshal(map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": newAnnotations,
+						},
+					})
+
+					if err := patchUpdatedNode(node.Name, mergePatch, b.k8sclient); err != nil {
+						klog.Errorf("bgp.reconcileNodes(): failed to save updated node with annotations %s: %v", node.Name, err)
+					} else {
+						klog.V(2).Infof("bgp.reconcileNodes(): annotations set on node %s", node.Name)
+					}
+				} else {
+					klog.V(2).Infof("bgp.reconcileNodes(): no change to annotations for %s", node.Name)
+				}
+			}
 		}
 	}
+	klog.V(2).Info("bgp.reconcileNodes(): complete")
 	return nil
 }
 
 // enableBGP enable bgp on the project
 func (b *bgp) enableBGP() error {
 	req := packngo.CreateBGPConfigRequest{
-		Asn:            asn,
+		Asn:            b.localASN,
 		DeploymentType: "local",
 		UseCase:        "kubernetes-load-balancer",
 	}
@@ -85,4 +147,39 @@ func ensureNodeBGPEnabled(id string, client *packngo.Client) error {
 	}
 	_, _, err = client.BGPSessions.Create(id, req)
 	return err
+}
+
+// getNodePeerAddress get the BGP peer address for a specific node
+func getNodePeerAddress(providerID string, client *packngo.Client) (address string, err error) {
+	id, err := deviceIDFromProviderID(providerID)
+	if err != nil {
+		return "", err
+	}
+	ips, _, err := client.DeviceIPs.List(id, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get device IPs for device %s: %v", id, err)
+	}
+	// we need to get the ip address that is all of:
+	// - AddressFamily == 4
+	// - Public == false
+	// - Management == true
+	var addr string
+	for _, ip := range ips {
+		if ip.AddressFamily == 4 && !ip.Public && ip.Management {
+			addr = ip.Network
+			break
+		}
+	}
+	if addr == "" {
+		return addr, errors.New("no matching IP address found that is private+ipv4+management")
+	}
+	return addr, nil
+}
+
+// patchUpdatedNode apply a patch to the node
+func patchUpdatedNode(name string, patch []byte, client kubernetes.Interface) error {
+	if _, err := client.CoreV1().Nodes().Patch(name, k8stypes.MergePatchType, patch); err != nil {
+		return fmt.Errorf("Failed to patch node %s: %v", name, err)
+	}
+	return nil
 }

--- a/packet/constants.go
+++ b/packet/constants.go
@@ -1,13 +1,16 @@
 package packet
 
 const (
-	metalLBNamespace     = "metallb-system"
-	metalLBConfigMapName = "config"
-	configMapResource    = "configmaps"
-	localASN             = 65000
-	peerASN              = 65530
-	hostnameKey          = "kubernetes.io/hostname"
-	packetIdentifier     = "packet-ccm-auto"
-	packetTag            = "usage=" + packetIdentifier
-	ccmIPDescription     = "Packet Kubernetes CCM auto-generated for Load Balancer"
+	metalLBNamespace          = "metallb-system"
+	metalLBConfigMapName      = "config"
+	configMapResource         = "configmaps"
+	hostnameKey               = "kubernetes.io/hostname"
+	packetIdentifier          = "packet-ccm-auto"
+	packetTag                 = "usage=" + packetIdentifier
+	ccmIPDescription          = "Packet Kubernetes CCM auto-generated for Load Balancer"
+	DefaultAnnotationNodeASN  = "packet.com/node.asn"
+	DefaultAnnotationPeerASNs = "packet.com/peer.asns"
+	DefaultAnnotationPeerIPs  = "packet.com/peer.ips"
+	DefaultLocalASN           = 65000
+	DefaultPeerASN            = 65530
 )


### PR DESCRIPTION
Fixes #39 

Sets BGP annotations on the nodes. Whenever a node comes up, it extracts the BGP peer IP, and sets the local and peer ASNs as annotations on the kubernetes node object. Also updates the README.

* The ASNs are 6500 and 65530, per the Packet docs, but can be overridden
* The annotations are `packet.com/node.asn`, `packet.com/peer.asns`, `packet.com/peer.ips`, but can be overridden

 