### PR TITLE
enable metallb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ ifndef PKG_LIST
 	$(eval PKG_LIST := $(shell $(BUILD_CMD) go list ./... | grep -v vendor))
 endif
 
-.PHONY: fmt-check lint test vet golint tag version
+.PHONY: fmt fmt-check lint test vet golint tag version
 
 $(DIST_DIR):
 	mkdir -p $@
@@ -102,6 +102,9 @@ fmt-check:
 	  $(BUILD_CMD) gofmt -s -e -d ${GO_FILES}; \
 	  exit 1; \
 	fi
+
+fmt:
+	$(BUILD_CMD) gofmt -w -s ${GO_FILES}
 
 golangci-lint: $(LINTER)
 $(LINTER):

--- a/README.md
+++ b/README.md
@@ -153,8 +153,6 @@ Packet does not offer managed load balancers like [AWS ELB](https://aws.amazon.c
 Instead, Packet uses BGP and [metallb](https://metallb.universe.tf) to provide the _equivalence_ of load balancing, without requiring an additional
 managed service (or hop).
 
-**Note:** The below load balancer behaviour is currently disabled. It will be enabled in a future release.
-
 By default, the load balancer is deployed. You can disable the load balancer when
 deploying the CCM, which will prevent the load balancer from running. To do so,
 you use one of these two options:
@@ -209,10 +207,11 @@ You can run the CCM locally on your laptop or VM, i.e. not in the cluster. This 
 1. Set the environment variable `CCM_SECRET` to a file with the secret contents as a json, i.e. the content of the secret's `stringData`, e.g. `CCM_SECRET=ccm-secret.json`
 1. Set the environment variable `KUBECONFIG` to a kubeconfig file with sufficient access to the cluster, e.g. `KUBECONFIG=mykubeconfig`
 1. Set the environment variable `PACKET_FACILITY_NAME` to the correct facility where the cluster is running, e.g. `PACKET_FACILITY_NAME=EWR1`
+1. Set the path to the loadbalancer manifest, available in this repository as [lb/manifests.yaml](./lib/manifests.yaml), e.g. `LB_MANIFEST=./lib/manifests.yaml`
 1. Run the command, e.g.:
 
 ```
-PACKET_FACILITY_NAME=EWR1 dist/bin/packet-cloud-controller-manager-darwin-amd64 --cloud-provider=packet --leader-elect=false --allow-untagged-cloud=true --authentication-skip-lookup=true --provider-config=$CCM_SECRET --kubeconfig=$KUBECONFIG
+PACKET_FACILITY_NAME=${PACKET_FACILITY_NAME} dist/bin/packet-cloud-controller-manager-darwin-amd64 --cloud-provider=packet --leader-elect=false --allow-untagged-cloud=true --authentication-skip-lookup=true --provider-config=$CCM_SECRET --load-balancer-manifest=$LB_MANIFEST --kubeconfig=$KUBECONFIG
 ```
 
 For lots of extra debugging, add `--v=2` or even higher levels, e.g. `--v=5`.

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214 // indirect
 	github.com/alexkohler/nakedret v1.0.0 // indirect
 	github.com/hashicorp/go-hclog v0.12.0 // indirect
-	github.com/hashicorp/go-retryablehttp v0.6.4
+	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f // indirect
 	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721
 	github.com/opennota/check v0.0.0-20180911053232-0c771f5545ff // indirect
 	github.com/packethost/metabot v1.0.0
-	github.com/packethost/packet-api-server v0.0.0-20191111173258-323bdfe6671d
-	github.com/packethost/packngo v0.2.1-0.20200220143658-05f78a847cb6
+	github.com/packethost/packet-api-server v0.0.0-20200706140707-f0f79ef89944
+	github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4
 	github.com/pallinder/go-randomdata v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
@@ -356,6 +357,8 @@ github.com/hashicorp/go-retryablehttp v0.6.2 h1:bHM2aVXwBtBJWxHtkSrWuI4umABCUczs
 github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
 github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
+github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
@@ -456,6 +459,7 @@ github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f/go.mod h1:AmCV4
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
 github.com/mholt/caddy v0.0.0-20180213163048-2de495001514/go.mod h1:Wb1PlT4DAYSqOEd03MsqkdkXnTxA8v9pKjdpxbqM1kY=
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
+github.com/mibk/dupl v1.0.0/go.mod h1:pCr4pNxxIbFGvtyCOi0c7LVjmV6duhKWV+ex5vh38ME=
 github.com/miekg/dns v0.0.0-20160614162101-5d001d020961/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -527,6 +531,8 @@ github.com/packethost/metabot v1.0.0 h1:MPuklLtKVPSn+qn/jTGUhKiIMIuMaSfqVZaP1lIc
 github.com/packethost/metabot v1.0.0/go.mod h1:JPDsNp5KlsBQms1TCnRFmOagcmFCjZ68/ydlfPT5r/Q=
 github.com/packethost/packet-api-server v0.0.0-20191111173258-323bdfe6671d h1:h2FMDNO2YtC+ZDTj9RKH07osLrJ6FA9oCojdv4dmLN4=
 github.com/packethost/packet-api-server v0.0.0-20191111173258-323bdfe6671d/go.mod h1:yTi5RK7+tGw57bN7RMYD9olsImqNffYSTA+Acwlrd+4=
+github.com/packethost/packet-api-server v0.0.0-20200706140707-f0f79ef89944 h1:JfXrldQ9t47ZBoAtKBh/9ARDW+W5FwPi5abHERBoMeU=
+github.com/packethost/packet-api-server v0.0.0-20200706140707-f0f79ef89944/go.mod h1:20y0oYV+wNTv4CnBEi30PiiSGOoDFtsk25g1Rs3w7kU=
 github.com/packethost/packngo v0.1.0 h1:G/5zumXb2fbPm5MAM3y8MmugE66Ehpio5qx0IhdhTPc=
 github.com/packethost/packngo v0.1.0/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/packethost/packngo v0.2.0 h1:mSlzOof8PsOWCy78sBMt/PwMJTEjjQ/rRvMixu4Nm6c=
@@ -535,6 +541,8 @@ github.com/packethost/packngo v0.2.1-0.20200212101111-dcebe8a749f8 h1:Dfw1Tf+p6d
 github.com/packethost/packngo v0.2.1-0.20200212101111-dcebe8a749f8/go.mod h1:lTgI4wr0T6uAIArEQtlx1wu+n0cEy+opDJpIBAHvQ34=
 github.com/packethost/packngo v0.2.1-0.20200220143658-05f78a847cb6 h1:GL+IdflHCr5+5S2wqXOq7F7D/gfIaZJwJWb5ogRxaKc=
 github.com/packethost/packngo v0.2.1-0.20200220143658-05f78a847cb6/go.mod h1:lTgI4wr0T6uAIArEQtlx1wu+n0cEy+opDJpIBAHvQ34=
+github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4 h1:T6L0ioYOSzOfX9/DzmeXMOuqJb3GldrVHJe4lLJw3Bk=
+github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4/go.mod h1:erURcsqYzwc9wSb04TX4so+s6F3uZtbXUil0W1LCGHA=
 github.com/pallinder/go-randomdata v1.2.0 h1:EJPxw+sgM1mbMW8RBu5zkG4FbloJpDOCCqPccdWto8A=
 github.com/pallinder/go-randomdata v1.2.0/go.mod h1:p8CasZQiWDLuaKy5ihVvdshqc7LlL6ovmRxAuNXgi3U=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
@@ -636,6 +644,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stripe/safesql v0.2.0 h1:xiefmCDd8c35PVSGrL2FhBiaKxviXnGziBDOpOejeBE=
 github.com/stripe/safesql v0.2.0/go.mod h1:q7b2n0JmzM1mVGfcYpanfVb2j23cXZeWFxcILPn3JV4=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -668,6 +677,7 @@ github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -706,6 +716,8 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 h1:7KByu05hhLed2MO29w7p1X
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a h1:y6sBfNd1b9Wy08a6K1Z1DZc4aXABUN5TKjkYhz7UKmo=
+golang.org/x/crypto v0.0.0-20200420201142-3c4aac89819a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -719,6 +731,7 @@ golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20170915142106-8351a756f30f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -749,6 +762,8 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
@@ -836,10 +851,13 @@ golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190909030654-5b82db07426d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 h1:bw9doJza/SFBEweII/rHQh338oozWyiFsBRHtrflcws=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200225230052-807dcd883420 h1:4RJNOV+2rLxMEfr6QIpC7GEv9MjD6ApGXTCLrNF9+eA=
 golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200702044944-0cc1aa72b347/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=

--- a/lb/manifests.yaml
+++ b/lb/manifests.yaml
@@ -291,3 +291,12 @@ spec:
         runAsUser: 65534
       serviceAccountName: controller
       terminationGracePeriodSeconds: 0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    peers: []

--- a/main.go
+++ b/main.go
@@ -30,8 +30,6 @@ const (
 	envVarAnnotationLocalASN = "PACKET_ANNOTATION_LOCAL_ASN"
 	envVarAnnotationPeerASNs = "PACKET_ANNOTATION_PEER_ASNS"
 	envVarAnnotationPeerIPs  = "PACKET_ANNOTATION_PEER_IPS"
-	// fixedDisableLoadBalancers disabled until the packet API is ready with IP management
-	fixedDisableLoadBalancers = true
 )
 
 var (
@@ -104,7 +102,7 @@ func getPacketConfig(providerConfig, loadBalancerManifestPath string) (packet.Co
 
 	disableLoadBalancer := os.Getenv(disableLoadBalancerName)
 	config.DisableLoadBalancer = rawConfig.DisableLoadBalancer
-	if disableLoadBalancer == "true" || fixedDisableLoadBalancers {
+	if disableLoadBalancer == "true" {
 		config.DisableLoadBalancer = true
 	}
 

--- a/packet/metallb/configmap.go
+++ b/packet/metallb/configmap.go
@@ -26,10 +26,11 @@ func (cfg *ConfigFile) Bytes() ([]byte, error) {
 }
 
 // AddPeer adds a peer. If a matching peer already exists, do not change anything
-func (cfg *ConfigFile) AddPeer(add *Peer) {
+// Returns if anything changed
+func (cfg *ConfigFile) AddPeer(add *Peer) bool {
 	// ignore empty peer; nothing to add
 	if add == nil {
-		return
+		return false
 	}
 	var found bool
 
@@ -46,9 +47,11 @@ func (cfg *ConfigFile) AddPeer(add *Peer) {
 		// they were equal, so we found a matcher
 		found = true
 	}
-	if !found {
-		cfg.Peers = append(cfg.Peers, *add)
+	if found {
+		return false
 	}
+	cfg.Peers = append(cfg.Peers, *add)
+	return true
 }
 
 // RemovePeer remove a peer. If the matching peer does not exist, do not change anything
@@ -82,11 +85,12 @@ func (cfg *ConfigFile) RemovePeerBySelector(remove *NodeSelector) {
 	cfg.Peers = peers
 }
 
-// AddAddressPool adds an address pool. If a matching pool already exists, do not change anything
-func (cfg *ConfigFile) AddAddressPool(add *AddressPool) {
+// AddAddressPool adds an address pool. If a matching pool already exists, do not change anything.
+// Returns if anything changed
+func (cfg *ConfigFile) AddAddressPool(add *AddressPool) bool {
 	// ignore empty peer; nothing to add
 	if add == nil {
-		return
+		return false
 	}
 	var found bool
 
@@ -98,9 +102,11 @@ func (cfg *ConfigFile) AddAddressPool(add *AddressPool) {
 		// they were equal, so we found a matcher
 		found = true
 	}
-	if !found {
-		cfg.Pools = append(cfg.Pools, *add)
+	if found {
+		return false
 	}
+	cfg.Pools = append(cfg.Pools, *add)
+	return true
 }
 
 // RemoveAddressPool remove a pool. If the matching pool does not exist, do not change anything

--- a/packet/metallb/configmap_test.go
+++ b/packet/metallb/configmap_test.go
@@ -415,53 +415,53 @@ func TestNodeSelectorsEqual(t *testing.T) {
 func TestSelectorRequirementsCompare(t *testing.T) {
 	// basic set we use for our tests.
 	ns := map[string]SelectorRequirements{
-		"empty": SelectorRequirements{},
-		"ad": SelectorRequirements{
+		"empty": {},
+		"ad": {
 			Key:      "a",
 			Operator: "d",
 			Values:   []string{},
 		},
-		"dd": SelectorRequirements{
+		"dd": {
 			Key:      "d",
 			Operator: "d",
 			Values:   []string{},
 		},
-		"ap": SelectorRequirements{
+		"ap": {
 			Key:      "a",
 			Operator: "p",
 			Values:   []string{},
 		},
-		"ap-values-empty": SelectorRequirements{
+		"ap-values-empty": {
 			Key:      "a",
 			Operator: "p",
 			Values:   []string{},
 		},
-		"ap-values-nil": SelectorRequirements{
+		"ap-values-nil": {
 			Key:      "a",
 			Operator: "p",
 			Values:   nil,
 		},
-		"ap-values-a": SelectorRequirements{
+		"ap-values-a": {
 			Key:      "a",
 			Operator: "p",
 			Values:   []string{"a"},
 		},
-		"ap-values-b": SelectorRequirements{
+		"ap-values-b": {
 			Key:      "a",
 			Operator: "p",
 			Values:   []string{"b"},
 		},
-		"ap-values-ab": SelectorRequirements{
+		"ap-values-ab": {
 			Key:      "a",
 			Operator: "p",
 			Values:   []string{"a", "b"},
 		},
-		"ap-values-ap": SelectorRequirements{
+		"ap-values-ap": {
 			Key:      "a",
 			Operator: "p",
 			Values:   []string{"a", "p"},
 		},
-		"ap-values-pa": SelectorRequirements{
+		"ap-values-pa": {
 			Key:      "a",
 			Operator: "p",
 			Values:   []string{"p", "a"},

--- a/util/manifests.go
+++ b/util/manifests.go
@@ -1,0 +1,165 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog"
+)
+
+// ApplyManifests parse and apply manifests to the kubernetes cluster
+func ApplyManifests(m []byte, client kubernetes.Interface) error {
+	// read each item in the manifest and deploy it
+	// if we could rely on everything being server-side apply, we could
+	// just pass it in as a patch, but that really only is supported
+	// properly from k8s 1.18.0, so we parse it locally, after splitting the
+	// manifests per https://yaml.org/spec/1.2/spec.html
+
+	// save to k8s
+	manifests, err := parseK8sYaml(m)
+	if err != nil {
+		return fmt.Errorf("error parsing manifests: %v", err)
+	}
+	for i, m := range manifests {
+		klog.V(2).Infof("applying manifest %d %v", i, m.GetObjectKind().GroupVersionKind())
+		// now figure out what kind it is
+		// for each kind, we get it. There are three possiblities:
+		// - got it, no error: Update()
+		// - not found, error: Create()
+		// - other error: return error
+		switch o := m.(type) {
+		case *v1.Namespace:
+			intf := client.CoreV1().Namespaces()
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *appsv1.Deployment:
+			intf := client.AppsV1().Deployments(o.ObjectMeta.Namespace)
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *appsv1.StatefulSet:
+			intf := client.AppsV1().StatefulSets(o.ObjectMeta.Namespace)
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *appsv1.DaemonSet:
+			intf := client.AppsV1().DaemonSets(o.ObjectMeta.Namespace)
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *v1.ConfigMap:
+			intf := client.CoreV1().ConfigMaps(o.ObjectMeta.Namespace)
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *rbacv1.Role:
+			intf := client.RbacV1().Roles(o.ObjectMeta.Namespace)
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *rbacv1.ClusterRole:
+			intf := client.RbacV1().ClusterRoles()
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *v1.ServiceAccount:
+			intf := client.CoreV1().ServiceAccounts(o.ObjectMeta.Namespace)
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *rbacv1.RoleBinding:
+			intf := client.RbacV1().RoleBindings(o.ObjectMeta.Namespace)
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *rbacv1.ClusterRoleBinding:
+			intf := client.RbacV1().ClusterRoleBindings()
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		case *policyv1.PodSecurityPolicy:
+			intf := client.PolicyV1beta1().PodSecurityPolicies()
+			existing, err := intf.Get(o.Name, metav1.GetOptions{})
+			if err == nil && existing != nil {
+				_, err = intf.Update(o)
+			} else {
+				_, err = intf.Create(o)
+			}
+		default:
+			err = fmt.Errorf("unknown type: %v", o)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error applying document %d: %v", i, err)
+		}
+	}
+	klog.V(2).Info("all manifests applied")
+	return nil
+}
+
+func parseK8sYaml(fileR []byte) ([]runtime.Object, error) {
+
+	acceptedK8sTypes := regexp.MustCompile(`(Role|ClusterRole|DaemonSet|RoleBinding|ClusterRoleBinding|ServiceAccount|Deployment|StatefulSet|Namespace|PodSecurityPolicy|ConfigMap)`)
+	sepYamlFiles := bytes.Split(fileR, []byte("---"))
+	retVal := make([]runtime.Object, 0, len(sepYamlFiles))
+	for i, f := range sepYamlFiles {
+		if len(f) == 0 || (len(f) == 1 && f[0] == 0x0a) {
+			// ignore empty cases
+			continue
+		}
+
+		decode := scheme.Codecs.UniversalDeserializer().Decode
+		obj, groupVersionKind, err := decode(f, nil, nil)
+
+		if err != nil {
+			return nil, fmt.Errorf("error while decoding YAML object %d: %v", i, err)
+		}
+
+		if !acceptedK8sTypes.MatchString(groupVersionKind.Kind) {
+			return nil, fmt.Errorf("manifest %d contained unsupport Kubernetes object type: %s", i, groupVersionKind.Kind)
+		}
+		retVal = append(retVal, obj)
+
+	}
+	return retVal, nil
+}


### PR DESCRIPTION
This largish PR does the following:

* enables load balancers using metallb by default on Packet CCM. It can be disabled by option, as listed in the README [here](https://github.com/packethost/packet-ccm#load-balancers)
* ensures it all syncs correctly
* adds a `make fmt` command that formats the files
* updates the README doc for running locally (usually during development) with the manifests