### PR TITLE
Improve deployment release process

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,53 +1,60 @@
 # CCM for Packet Build and Design
+
 The Cloud Controller Manager (CCM) Packet plugin enables a Kubernetes cluster to interface directly with
 Packet cloud services.
 
 ## Deploy
+
 Read how to deploy the Kubernetes CCM for Packet in the [README.md](./README.md)!
 
 ## Building
+
 To build the binary, run:
 
-```
+```console
 make build
 ```
 
 It will deposit the binary for your local architecture as `dist/bin/packet-cloud-controller-manager--$(OS)-$(ARCH)`
 
-By default `make build` builds the binary using your locally installed go toolchain.
+By default `make build` builds the binary using your locally installed go tool-chain.
 To build it using a docker container, do:
 
-```
+```console
 make build DOCKERBUILD=true
 ```
 
 By default, it will build for your local operating system and CPU architecture. You can build for alternate architectures or operating systems via the `OS` and `ARCH` parameters:
 
-```
+```console
 make build OS=darwin
 make build OS=linux ARCH=arm64
 ```
 
 ## Docker Image
+
 To build a docker image, run:
 
-```
+```console
 make image
 ```
 
 The image will be tagged with `:latest`
 
 ## CI/CD/Release pipeline
+
 The CI/CD/Release pipeline is run via the following steps:
 
 * `make ci`: builds the binary, runs all tests, builds the OCI image
 * `make cd`: takes the image from the prior stage, tags it with the name of the branch and git hash from the commit, and pushes to the docker registry
+* `make prerelease`: updates README.md and creates deployment manifests
 * `make release`: takes the image from the `ci` stage, tags it with the git tag, and pushes to the docker registry
 
 The assumptions about workflow are as follows:
 
 * `make ci` can be run anywhere. The built binaries and OCI image will be named and tagged as per `make build` and `make image` above.
 * `make cd` should be run only on a merge into `master`. It generally will be run only in a CI system, e.g. [drone](https://drone.io) or [github actions](https://github.com/features/actions). It requires passing both `CONFIRM=true` to tell it that it is ok to push, and `BRANCH_NAME=${BRANCH_NAME}` to tell it what tag should be used in addition to the git hash. For example, to push out the current commit as master: `make cd CONFIRM=true BRANCH_NAME=master`
+* `make prerelease` should be run locally. It requires passing `RELEASE_TAG=${RELEASE_TAG}` to tell it what tag to use when updating `README.md` and creating `deploy/release` files.
 * `make release` should be run only on applying a tag to `master`, although it can run elsewhere. It generally will be run only in a CI system. It requires passing both `CONFIRM=true` to tell it that it is ok to push, and `RELEASE_TAG=${RELEASE_TAG}` to tell it what tag this release should be. For example, to push out a tagged version `v1.2.3` on the current commit: `make release CONFIRM=true RELEASE_TAG=v1.2.3`.
 
 For both `make cd` and `make release`, if you wish to push out a _different_ commit, then check that one out first.
@@ -59,7 +66,7 @@ The flow to make changes normally should be:
 3. Make your changes in your working branch, commit and push.
 4. Open a Pull Request or Merge Request from the branch to `master`. This will cause `make ci` to run.
 5. When CI passes and maintainers approve, merge the PR/MR into `master`. This will cause `make ci` and `make cd CONFIRM=true BRANCH_NAME=master` to run, pushing out images tagged with `:master` and `:${GIT_HASH}`
-6. When a particular commit is ready to cut a release, **on master** add a git tag and push. This will cause `make release CONFIRM=true RELEASE_TAG=<applied git tag>` to run, pushing out an image tagged with `:${RELEASE_TAG}`
+6. When a particular commit is ready to cut a release, **on master**, run `make prerelease`, stage (`git add`) the new files and commit the changes, add a git tag and push. This will cause `make release CONFIRM=true RELEASE_TAG=<applied git tag>` to run, pushing out an image tagged with `:${RELEASE_TAG}`
 
 ## Design
 
@@ -73,7 +80,7 @@ The main entrypoint command is in [main.go](./main.go), and provides fairly stan
 1. import the main app from [k8s.io/kubernetes/cmd/cloud-controller-manager/app](https://godoc.org/k8s.io/kubernetes/cmd/cloud-controller-manager/app)
 1. `main()`:
    1. initialize the command
-	 1. call `command.Execute()`
+      1. call `command.Execute()`
 
 The packet-specific logic is in [github.com/packethost/packet-ccm/packet](./packet/), which, as described before,
 is imported into `main.go`. The blank `import _` is used solely for the side-effects, i.e. to cause the `init()`

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: packet-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    app: packet-cloud-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: packet-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        app: packet-cloud-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      dnsPolicy: Default
+      hostNetwork: true
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+        # this taint is set by all kubelets running `--cloud-provider=external`
+        # so we should tolerate it to schedule the packet ccm
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        # cloud controller manager should be able to run on masters
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+      containers:
+      - image: packethost/packet-ccm:$RELEASE_TAG
+        name: packet-cloud-controller-manager
+        command:
+          - "./packet-cloud-controller-manager"
+          - "--cloud-provider=packet"
+          - "--leader-elect=false"
+          - "--allow-untagged-cloud=true"
+          - "--authentication-skip-lookup=true"
+          - "--provider-config=/etc/cloud-sa/cloud-sa.json"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        volumeMounts:
+          - name: cloud-sa-volume
+            readOnly: true
+            mountPath: "/etc/cloud-sa"
+      volumes:
+        - name: cloud-sa-volume
+          secret:
+            secretName: packet-cloud-config
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system


### PR DESCRIPTION
_Rethinking to take https://github.com/packethost/packet-ccm/pull/56#issuecomment-656157033 into consideration_

This PR Improves CCM deployment releases.

* Adds `make prerelease RELEASE_VERSION={RELEASE_VERSIOM}`
  * revises URLs in README.md
  * creates new `deploy/release/{RELEASE_VERSION}` files (from a template)
* Updates `BUILD.md` on the use of `make prerelease`
* Markdown linting fixes were applied to BUILD.md for readability.

Closes #55