### PR TITLE
add missing v1.0.1 release yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please read through the requirements carefully as they are critical to running t
 ### Version
 Recommended versions of Packet CCM based on your Kubernetes version:
 * Packet CCM version v0.0.4 supports Kubernetes version >=v1.10
-* Packet CCM version v1.0.0 support Kubernetes version >=1.15.0
+* Packet CCM version v1.0.0+ supports Kubernetes version >=1.15.0
 
 ## Deployment
 
@@ -89,7 +89,7 @@ packet-cloud-config   Opaque                                1         2m
 You can apply the rest of the CCM by using `kubectl` to apply `deploy/releases/<version>/deployment.yaml`, e.g:
 
 ```bash
-kubectl apply -f deploy/releases/v1.0.0/deployment.yaml
+kubectl apply -f deploy/releases/v1.0.1/deployment.yaml
 ```
 
 ### Logging

--- a/deploy/releases/v1.0.1/deployment.yaml
+++ b/deploy/releases/v1.0.1/deployment.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: packet-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    app: packet-cloud-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: packet-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        app: packet-cloud-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      dnsPolicy: Default
+      hostNetwork: true
+      serviceAccountName: cloud-controller-manager
+      tolerations:
+        # this taint is set by all kubelets running `--cloud-provider=external`
+        # so we should tolerate it to schedule the packet ccm
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        # cloud controller manager should be able to run on masters
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+      containers:
+      - image: packethost/packet-ccm:v1.0.1
+        name: packet-cloud-controller-manager
+        command:
+          - "./packet-cloud-controller-manager"
+          - "--cloud-provider=packet"
+          - "--leader-elect=false"
+          - "--allow-untagged-cloud=true"
+          - "--authentication-skip-lookup=true"
+          - "--provider-config=/etc/cloud-sa/cloud-sa.json"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        volumeMounts:
+          - name: cloud-sa-volume
+            readOnly: true
+            mountPath: "/etc/cloud-sa"
+      volumes:
+        - name: cloud-sa-volume
+          secret:
+            secretName: packet-cloud-config
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system


### PR DESCRIPTION
Originally from https://github.com/packethost/packet-ccm/pull/56#issuecomment-655528837

This adds the missing chart for the v1.0.1 release and updates the README.md to reflect this as the latest version.