### PR TITLE
add VERSION and apply this to the UserAgent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION=$(RELEASE_TAG)-$(VERSION)
 endif
 GO_FILES := $(shell find . -type f -not -path './vendor/*' -name '*.go')
 FROMTAG ?= latest
-LDFLAGS ?= -ldflags '-extldflags "-static" -X "$(PACKAGE_NAME)/pkg/version.VERSION=$(VERSION)"'
+LDFLAGS ?= -ldflags '-extldflags "-static" -X "$(PACKAGE_NAME)/version.VERSION=$(VERSION)"'
 
 # which arches can we support
 ARCHES=arm64 amd64

--- a/packet/cloud.go
+++ b/packet/cloud.go
@@ -89,6 +89,7 @@ func newCloud(packetConfig Config, client *packngo.Client) (cloudprovider.Interf
 func InitializeProvider(packetConfig Config) error {
 	// set up our client and create the cloud interface
 	client := packngo.NewClientWithAuth("", packetConfig.AuthToken, nil)
+	client.UserAgent = fmt.Sprintf("packet-ccm/%s %s", VERSION, client.UserAgent)
 	cloud, err := newCloud(packetConfig, client)
 	if err != nil {
 		return fmt.Errorf("failed to create new cloud handler: %v", err)

--- a/packet/version.go
+++ b/packet/version.go
@@ -1,0 +1,8 @@
+// This file does not need to be updated. Release versions are set at build time (see LDFLAGS in the Makefile)
+
+package packet
+
+var (
+	// VERSION is reported in the API User-Agent
+	VERSION = "devel"
+)


### PR DESCRIPTION
_Originally from https://github.com/packethost/packet-ccm/pull/56#issuecomment-655528837_

This PR adds packet.VERSION and uses this in the packngo.UserAgent.  The Makefile was already applying the version at build time, but it was referencing a missing version variable (which we now have).

Closes #54