### PR TITLE
include manifests in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG OS=linux
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY dist/bin/${BINARY}-${OS}-${ARCH} ${BINARY}
+COPY lb/manifests.yaml lb/manifests.yaml
 
 # because you cannot use ARG or ENV in CMD when in [] mode, and with "FROM scratch", we have no shell
-CMD ["./packet-cloud-controller-manager"]
+ENTRYPOINT ["./packet-cloud-controller-manager"]

--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ You can run the CCM locally on your laptop or VM, i.e. not in the cluster. This 
 
 1. Deploy everything except for the `Deployment` and, optionally, the `Secret`
 1. Build it for your local platform `make build`
-1. Set the environment variable `CCM_SECRET` to a file with the secret contents as a json, i.e. the content of the secret's `stringData`, e.g. `CCM_SECRET=ccm-secret.json`
+1. Set the environment variable `CCM_SECRET` to a file with the secret contents as a json, i.e. the content of the secret's `stringData`, e.g. `CCM_SECRET=ccm-secret.yaml`
 1. Set the environment variable `KUBECONFIG` to a kubeconfig file with sufficient access to the cluster, e.g. `KUBECONFIG=mykubeconfig`
 1. Set the environment variable `PACKET_FACILITY_NAME` to the correct facility where the cluster is running, e.g. `PACKET_FACILITY_NAME=EWR1`
-1. Set the path to the loadbalancer manifest, available in this repository as [lb/manifests.yaml](./lib/manifests.yaml), e.g. `LB_MANIFEST=./lib/manifests.yaml`
+1. If you want to use a different path to the loadbalancer manifest, available in this repository as [lb/manifests.yaml](./lib/manifests.yaml), e.g. `LB_MANIFEST=./lb/manifests.yaml` and set it to the argument `--load-balancer-manifest=$LB_MANIFEST`; the CCM default is `./lb/manifests.yaml`
 1. Run the command, e.g.:
 
 ```

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	// add our config
 	command.PersistentFlags().StringVar(&providerConfig, "provider-config", "", "path to provider config file")
-	command.PersistentFlags().StringVar(&loadBalancerManifestPath, "load-balancer-manifest", "", "path to load-balancer manifests")
+	command.PersistentFlags().StringVar(&loadBalancerManifestPath, "load-balancer-manifest", "lb/manifests.yaml", "path to load-balancer manifests")
 
 	logs.InitLogs()
 	defer logs.FlushLogs()


### PR DESCRIPTION
This does a few things:

* includes the metallb manifests in the docker image
* sets the default path in the binary for the manifests to `lb/manifests.yaml`
* updates the README to correctly explain how to use it
