### PR TITLE
Do not build for releases, only tag existing images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
     - master
-    tags:
-    - 'v*'
 
 jobs:
   report:
@@ -41,11 +39,8 @@ jobs:
       run: make image-all
     # the rest of these only work if we push to master or pushed a tag
     - name: hub login
-      if: github.event_name == 'push' && (endsWith(github.ref,'/master') || startsWith(github.ref,'refs/tags/'))
+      if: github.event_name == 'push' && endsWith(github.ref,'/master')
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
     - name: deploy   # when merged into master, tag master and push - ideally, this would be a separate job, but you cannot share docker build cache between jobs
       if: github.event_name == 'push' && endsWith(github.ref,'/master')
       run: make cd CONFIRM=true BRANCH_NAME=master
-    - name: release images  # when based on a tag, tag master and push - ideally, this would be a separate job, but you cannot share docker build cache between jobs
-      if: github.event_name == 'push' && startsWith(github.ref,'refs/tags/')
-      run: make release CONFIRM=true # this pushes out the various images to docker hub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,21 @@ on:
     - 'v*'
 
 jobs:
-  release:
+  images: # create images in docker hub
+    name: Images
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: release tag
+      id: release_tag
+      run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+    - name: hub login
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+    - name: release images
+      run: make release CONFIRM=true
+
+  release: # create a github actions release with necessary artifacts
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The prior workflow as far as docker hub was concerned was:

* for all pushes to master (PR merges or tags): build the images and push them out
* for tag pushes (releases): build the images, push them out, then pull+tag/with/semver+push

This was wasteful; this is no reason to go through the entire build cycle, if the images already exist for that commit. If they do not, we should not be building anyways, but failing.

This changes it as follows:

* for all pushes to master _not including tags_: build the images and push them out
* for tag pushes: pull/tag/push

The release creation and artifacts are unchanged.