### PR TITLE
sending wrong plan name

### DIFF
--- a/packet/devices.go
+++ b/packet/devices.go
@@ -128,7 +128,7 @@ func (i *instances) InstanceType(_ context.Context, nodeName types.NodeName) (st
 		return "", err
 	}
 
-	return device.Plan.Slug, nil
+	return device.Plan.Name, nil
 }
 
 // InstanceTypeByProviderID returns the type of the specified instance.
@@ -139,7 +139,7 @@ func (i *instances) InstanceTypeByProviderID(_ context.Context, providerID strin
 		return "", err
 	}
 
-	return device.Plan.Slug, nil
+	return device.Plan.Name, nil
 }
 
 // AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances

--- a/packet/devices_test.go
+++ b/packet/devices_test.go
@@ -149,7 +149,7 @@ func TestInstanceType(t *testing.T) {
 	}{
 		{"", "", fmt.Errorf("node name cannot be empty")},          // empty name
 		{"thisdoesnotexist", "", fmt.Errorf("instance not found")}, // unknown name
-		{devName, dev.Plan.Slug, nil},                              // valid
+		{devName, dev.Plan.Name, nil},                              // valid
 	}
 
 	for i, tt := range tests {
@@ -180,7 +180,7 @@ func TestInstanceTypeByProviderID(t *testing.T) {
 		{"foo-bar-abcdefg", "", fmt.Errorf("instance not found")},                              // invalid format
 		{"aws://abcdef5667", "", fmt.Errorf("provider name from providerID should be packet")}, // not packet
 		{"packet://acbdef-56788", "", fmt.Errorf("instance not found")},                        // unknown ID
-		{fmt.Sprintf("packet://%s", dev.ID), dev.Plan.Slug, nil},                               // valid
+		{fmt.Sprintf("packet://%s", dev.ID), dev.Plan.Name, nil},                               // valid
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Fixes #73 

This fixes it. Before, it was

```yaml
    node.kubernetes.io/instance-type: baremetal_0
    topology.kubernetes.io/region: ewr1
```

with this, it is

```yaml
    node.kubernetes.io/instance-type: t1.small.x86
    topology.kubernetes.io/region: ewr1
```