### PR TITLE
ensure CCM has access to configmaps

### DIFF
--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -132,6 +132,17 @@ rules:
   - list
   - watch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Without access to configmaps, it could not set up metallb properly.

These access rights really should be restricted a little better, but for now, let's fix this real user's problem, and then worry about it.