### PR TITLE
have mode to sync everything

### DIFF
--- a/packet/const.go
+++ b/packet/const.go
@@ -1,0 +1,9 @@
+package packet
+
+type UpdateMode int
+
+const (
+	ModeAdd UpdateMode = iota
+	ModeRemove
+	ModeSync
+)

--- a/packet/eip_controlplane_reconciliation.go
+++ b/packet/eip_controlplane_reconciliation.go
@@ -72,7 +72,7 @@ func (m *controlPlaneEndpointManager) serviceReconciler() serviceReconciler {
 	return m.reconcileServices
 }
 
-func (m *controlPlaneEndpointManager) reconcileNodes(nodes []*v1.Node, remove bool) error {
+func (m *controlPlaneEndpointManager) reconcileNodes(nodes []*v1.Node, mode UpdateMode) error {
 	klog.V(2).Info("controlPlaneEndpoint.reconcile: new reconciliation")
 	if m.inProcess {
 		klog.V(2).Info("controlPlaneEndpoint.reconcileNodes: already in process, not starting a new one")
@@ -91,7 +91,7 @@ func (m *controlPlaneEndpointManager) reconcileNodes(nodes []*v1.Node, remove bo
 	if err != nil {
 		return err
 	}
-	controlPlaneEndpoint := ipReservationByTags([]string{m.eipTag}, ipList)
+	controlPlaneEndpoint := ipReservationByAllTags([]string{m.eipTag}, ipList)
 	if controlPlaneEndpoint == nil {
 		// IP NOT FOUND nothing to do here.
 		klog.Errorf("elastic IP not found. Please verify you have one with the expected tag: %s", m.eipTag)
@@ -200,7 +200,7 @@ func newControlPlaneEndpointManager(eipTag, projectID string, deviceIPSrv packng
 
 // reconcileServices ensure that our Elastic IP is assigned as `externalIPs` for
 // the `default/kubernetes` service
-func (m *controlPlaneEndpointManager) reconcileServices(svcs []*v1.Service, remove bool) error {
+func (m *controlPlaneEndpointManager) reconcileServices(svcs []*v1.Service, mode UpdateMode) error {
 	if m.eipTag == "" {
 		return errors.New("elastic ip tag is empty. Nothing to do")
 	}
@@ -213,7 +213,7 @@ func (m *controlPlaneEndpointManager) reconcileServices(svcs []*v1.Service, remo
 	if err != nil {
 		return err
 	}
-	controlPlaneEndpoint := ipReservationByTags([]string{m.eipTag}, ipList)
+	controlPlaneEndpoint := ipReservationByAllTags([]string{m.eipTag}, ipList)
 	if controlPlaneEndpoint == nil {
 		// IP NOT FOUND nothing to do here.
 		klog.Errorf("elastic IP not found. Please verify you have one with the expected tag: %s", m.eipTag)

--- a/packet/ipreservations.go
+++ b/packet/ipreservations.go
@@ -4,10 +4,21 @@ import (
 	"github.com/packethost/packngo"
 )
 
-// ipReservationByTags given a set of packngo.IPAddressReservation and a set of tags, find
-// the reservations that have those tags
-func ipReservationByTags(targetTags []string, ips []packngo.IPAddressReservation) *packngo.IPAddressReservation {
+// ipReservationByAllTags given a set of packngo.IPAddressReservation and a set of tags, find
+// the first reservation that has all of those tags
+func ipReservationByAllTags(targetTags []string, ips []packngo.IPAddressReservation) *packngo.IPAddressReservation {
+	ret := ipReservationsByAllTags(targetTags, ips)
+	if len(ret) > 0 {
+		return ret[0]
+	}
+	return nil
+}
+
+// ipReservationsByAllTags given a set of packngo.IPAddressReservation and a set of tags, find
+// all of the reservations that have all of those tags
+func ipReservationsByAllTags(targetTags []string, ips []packngo.IPAddressReservation) []*packngo.IPAddressReservation {
 	// cycle through the IPs, looking for one that matches ours
+	ret := []*packngo.IPAddressReservation{}
 ips:
 	for i, ip := range ips {
 		tagMatches := map[string]bool{}
@@ -27,8 +38,42 @@ ips:
 			}
 		}
 		// if we made it here, we matched
-		return &ips[i]
+		ret = append(ret, &ips[i])
+	}
+	return ret
+}
+
+// ipReservationByAnyTags given a set of packngo.IPAddressReservation and a set of tags, find
+// the first reservation that has any of those tags
+func ipReservationByAnyTags(targetTags []string, ips []packngo.IPAddressReservation) *packngo.IPAddressReservation {
+	ret := ipReservationsByAnyTags(targetTags, ips)
+	if len(ret) > 0 {
+		return ret[0]
+	}
+	return nil
+}
+
+// ipReservationsByAnyTags given a set of packngo.IPAddressReservation and a set of tags, find
+// the reservations that have any of those tags
+func ipReservationsByAnyTags(targetTags []string, ips []packngo.IPAddressReservation) []*packngo.IPAddressReservation {
+	ret := []*packngo.IPAddressReservation{}
+	tagMatches := map[string]bool{}
+	for _, t := range targetTags {
+		tagMatches[t] = true
+	}
+	// cycle through the IPs, looking for one or more that match
+	for i, ip := range ips {
+		var found bool
+		for _, tag := range ip.Tags {
+			if _, ok := tagMatches[tag]; ok {
+				found = true
+				break
+			}
+		}
+		if found {
+			ret = append(ret, &ips[i])
+		}
 	}
 	// if we made it here, nothing matched
-	return nil
+	return ret
 }

--- a/packet/ipreservations_test.go
+++ b/packet/ipreservations_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/packethost/packngo"
 )
 
-func TestIPReservationByTags(t *testing.T) {
+func TestIPReservationByAllTags(t *testing.T) {
 	ips := []packngo.IPAddressReservation{
 		{IpAddressCommon: packngo.IpAddressCommon{Tags: []string{"a", "b"}}},
 		{IpAddressCommon: packngo.IpAddressCommon{Tags: []string{"c", "d"}}},
@@ -19,17 +19,60 @@ func TestIPReservationByTags(t *testing.T) {
 		match int
 	}{
 		{[]string{"a"}, 0},
+		{[]string{"a", "b"}, 0},
 		{[]string{"b"}, 0},
 		{[]string{"c"}, 1},
 		{[]string{"d"}, 1},
 		{[]string{"q"}, 4},
+		{[]string{"q", "n"}, -1},
 	}
 
 	for i, tt := range tests {
-		matched := ipReservationByTags(tt.tags, ips)
-		if matched != &ips[tt.match] {
+		matched := ipReservationByAllTags(tt.tags, ips)
+		switch {
+		case matched == nil && tt.match >= 0:
+			t.Errorf("%d: found no match but expected index %d", i, tt.match)
+		case matched != nil && tt.match < 0:
+			t.Errorf("%d: found a match but expected none", i)
+		case matched == nil && tt.match < 0:
+			// this is good
+		case matched != &ips[tt.match]:
 			t.Errorf("%d: match did not find index %d", i, tt.match)
 		}
 	}
+}
 
+func TestIPReservationByAnyTags(t *testing.T) {
+	ips := []packngo.IPAddressReservation{
+		{IpAddressCommon: packngo.IpAddressCommon{Tags: []string{"a", "b"}}},
+		{IpAddressCommon: packngo.IpAddressCommon{Tags: []string{"c", "d"}}},
+		{IpAddressCommon: packngo.IpAddressCommon{Tags: []string{"a", "d"}}},
+		{IpAddressCommon: packngo.IpAddressCommon{Tags: []string{"b", "c"}}},
+		{IpAddressCommon: packngo.IpAddressCommon{Tags: []string{"b", "q"}}},
+	}
+	tests := []struct {
+		tags  []string
+		match int
+	}{
+		{[]string{"a", "c"}, 0},
+		{[]string{"b", "q"}, 0},
+		{[]string{"c", "n"}, 1},
+		{[]string{"d", "l"}, 1},
+		{[]string{"q", "g"}, 4},
+		{[]string{"r", "g"}, -1},
+	}
+
+	for i, tt := range tests {
+		matched := ipReservationByAnyTags(tt.tags, ips)
+		switch {
+		case matched == nil && tt.match >= 0:
+			t.Errorf("%d: found no match but expected index %d", i, tt.match)
+		case matched != nil && tt.match < 0:
+			t.Errorf("%d: found a match but expected none", i)
+		case matched == nil && tt.match < 0:
+			// this is good
+		case matched != &ips[tt.match]:
+			t.Errorf("%d: match did not find index %d", i, tt.match)
+		}
+	}
 }


### PR DESCRIPTION
Fixes #89 

We have an issue wherein this captures events as they happen, but if the ccm is down (e.g. pod restart or move), it won't actually do the correct deletes of nodes (from `peers`) or services (delete the EIP and remove from `pools` in configmap).

This fixes all of that by creating 3 modes for reconciliation functions:

* add: add whatever nodes/services it receives (idempotently, obviously)
* remove: remove whatever nodes/services it receives
* sync: take the provides list as authoritative, and make sure that the list of EIPs, peers and pools precisely matches that list

We already ran sync once per minute, but we didn't cover every use case.
