### PR TITLE
Add support for BGP node selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ on a node in a different facility, or even outside of Equinix Metal entirely.
 
 ### BGP
 
-The Equinix Metal CCM enables BGP for the project and enables it on all nodes as they come up. It sets the ASNs as follows:
+The Equinix Metal CCM enables BGP for the project and enables it by default on all nodes as they come up. It sets the ASNs as follows:
 
 * Node, a.k.a. local, ASN: 65000
 * Peer Router ASN: 65530
@@ -172,6 +172,13 @@ _not_ recommended to override them. However, the settings are set as follows:
 1. If the environment variables `PACKET_LOCAL_ASN` and `PACKET_PEER_ASN` are set. Else...
 1. If the config file has fields named `localASN` and `peerASN`. Else...
 1. Use the above defaults.
+
+Set of servers on which BGP will be enabled can be filtered using the following settings:
+1. If the environment variable `PACKET_BGP_NODE_SELECTOR` is set. Else...
+1. If the config file has field named `bgpNodeSelector` set. Else...
+1. Select all nodes.
+
+Value for node selector should be a valid Kubernetes label selector (e.g. key1=value1,key2=value2).
 
 In addition to enabling BGP and setting ASNs, the Equinix Metal CCM sets Kubernetes annotations on the nodes. It sets the
 following information:

--- a/packet/cloud.go
+++ b/packet/cloud.go
@@ -70,7 +70,7 @@ func newCloud(packetConfig Config, client *packngo.Client) (cloudprovider.Interf
 		instances:                   i,
 		zones:                       newZones(client, packetConfig.ProjectID),
 		loadBalancer:                newLoadBalancers(client, packetConfig.ProjectID, packetConfig.Facility, packetConfig.LoadBalancerConfigMap, packetConfig.LocalASN, packetConfig.PeerASN),
-		bgp:                         newBGP(client, packetConfig.ProjectID, packetConfig.LocalASN, packetConfig.PeerASN, packetConfig.AnnotationLocalASN, packetConfig.AnnotationPeerASNs, packetConfig.AnnotationPeerIPs),
+		bgp:                         newBGP(client, packetConfig.ProjectID, packetConfig.LocalASN, packetConfig.PeerASN, packetConfig.AnnotationLocalASN, packetConfig.AnnotationPeerASNs, packetConfig.AnnotationPeerIPs, packetConfig.BGPNodeSelector),
 		controlPlaneEndpointManager: newControlPlaneEndpointManager(packetConfig.EIPTag, packetConfig.ProjectID, client.DeviceIPs, client.ProjectIPs, i, packetConfig.APIServerPort),
 	}, nil
 }

--- a/packet/config.go
+++ b/packet/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	AnnotationPeerIPs     string  `json:"annotationPeerIPs,omitEmpty"`
 	EIPTag                string  `json:"eipTag,omitEmpty"`
 	APIServerPort         int     `json:"apiServerPort,omitEmpty"`
+	BGPNodeSelector       string  `json:"bgpNodeSelector,omitEmpty"`
 }
 
 // String converts the Config structure to a string, while masking hidden fields.
@@ -39,5 +40,7 @@ func (c Config) Strings() []string {
 	ret = append(ret, fmt.Sprintf("local ASN: '%d'", c.LocalASN))
 	ret = append(ret, fmt.Sprintf("Elastic IP Tag: '%s'", c.EIPTag))
 	ret = append(ret, fmt.Sprintf("API Server Port: '%d'", c.APIServerPort))
+	ret = append(ret, fmt.Sprintf("BGP Node Selector: '%s'", c.BGPNodeSelector))
+
 	return ret
 }


### PR DESCRIPTION
In some large clusters, one may want to have dedicated pool of Ingress
nodes, which will be handling ingress traffic. CCM currently enables BGP
on all nodes in the cluster.

Enabling BGP on all nodes in the cluster also has security implications,
as now every node can start running it's own BGP speaker and start
capturing incoming traffic.

This patch adds support for new configuration option called BGP Node
Selector, which allows specifying Kubernetes Label selector, which will
be used for filtering the nodes, which will have BGP enabled.

To preserve existing behavior, by default all Nodes are selected.

Closes #100

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>