### PR TITLE
Add stub support for clusterID

### DIFF
--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -39,7 +39,6 @@ spec:
           - "./packet-cloud-controller-manager"
           - "--cloud-provider=packet"
           - "--leader-elect=false"
-          - "--allow-untagged-cloud=true"
           - "--authentication-skip-lookup=true"
           - "--provider-config=/etc/cloud-sa/cloud-sa.json"
         resources:

--- a/packet/cloud.go
+++ b/packet/cloud.go
@@ -169,7 +169,7 @@ func (c *cloud) ProviderName() string {
 // HasClusterID returns true if a ClusterID is required and set
 func (c *cloud) HasClusterID() bool {
 	klog.V(5).Info("called HasClusterID")
-	return false
+	return true
 }
 
 // startNodesWatcher start a goroutine that watches k8s for nodes and calls any handlers

--- a/packet/cloud_test.go
+++ b/packet/cloud_test.go
@@ -152,7 +152,7 @@ func TestProviderName(t *testing.T) {
 func TestHasClusterID(t *testing.T) {
 	vc, _ := testGetValidCloud(t)
 	cid := vc.HasClusterID()
-	expectedCid := false
+	expectedCid := true
 	if cid != expectedCid {
 		t.Errorf("returned %v instead of expected %v", cid, expectedCid)
 	}


### PR DESCRIPTION
As per kubernetes/cloud-provider#12 the
ClusterID requirement was never really followed through on, so the
flag is probably going to be removed in the future.

See also
https://github.com/brandond/k3s/commit/e109f13382909f41f0377b3fcd4bcc340510266b

I tested this and I didn't notice any side-effects.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>