### PR TITLE
Configmap is succesfully ignored and status updated

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,8 +115,13 @@ func getPacketConfig(providerConfig string) (packet.Config, error) {
 	if config.LoadBalancerConfigMap == "" {
 		config.LoadBalancerConfigMap = defaultLoadBalancerConfigMap
 	}
+
 	if config.LoadBalancerConfigMap == "disabled" {
 		config.LoadBalancerConfigMap = ""
+	}
+
+	if loadBalancerConfigMap == "none" {
+		config.LoadBalancerConfigMap = loadBalancerConfigMap
 	}
 
 	facility := os.Getenv(facilityName)

--- a/main.go
+++ b/main.go
@@ -107,21 +107,25 @@ func getPacketConfig(providerConfig string) (packet.Config, error) {
 
 	loadBalancerConfigMap := os.Getenv(loadBalancerConfigMapName)
 	config.LoadBalancerConfigMap = rawConfig.LoadBalancerConfigMap
+
+	// Configmap behaviour:
+	// If it isn't blank, set it to the input
+	// If it is blank, set it to the default
+	// If it isn't blank but is "disabled" then disable cconfigmap watching
+
 	// rule for processing: any setting in env var overrides setting from file
 	if loadBalancerConfigMap != "" {
 		config.LoadBalancerConfigMap = loadBalancerConfigMap
+		config.ConfigMapEnable = true
 	}
 	// and set for default
 	if config.LoadBalancerConfigMap == "" {
 		config.LoadBalancerConfigMap = defaultLoadBalancerConfigMap
+		config.ConfigMapEnable = true
 	}
-
 	if config.LoadBalancerConfigMap == "disabled" {
-		config.LoadBalancerConfigMap = ""
-	}
-
-	if loadBalancerConfigMap == "none" {
-		config.LoadBalancerConfigMap = loadBalancerConfigMap
+		config.LoadBalancerConfigMap = "disabled"
+		config.ConfigMapEnable = false
 	}
 
 	facility := os.Getenv(facilityName)

--- a/packet/cloud.go
+++ b/packet/cloud.go
@@ -68,7 +68,7 @@ func newCloud(packetConfig Config, client *packngo.Client) (cloudprovider.Interf
 		facility:                    packetConfig.Facility,
 		instances:                   i,
 		zones:                       newZones(client, packetConfig.ProjectID),
-		loadBalancer:                newLoadBalancers(client, packetConfig.ProjectID, packetConfig.Facility, packetConfig.LoadBalancerConfigMap, packetConfig.LocalASN, packetConfig.PeerASN),
+		loadBalancer:                newLoadBalancers(client, packetConfig.ProjectID, packetConfig.Facility, packetConfig.LoadBalancerConfigMap, packetConfig.ConfigMapEnable, packetConfig.LocalASN, packetConfig.PeerASN),
 		bgp:                         newBGP(client, packetConfig.ProjectID, packetConfig.LocalASN, packetConfig.PeerASN, packetConfig.AnnotationLocalASN, packetConfig.AnnotationPeerASNs, packetConfig.AnnotationPeerIPs),
 		controlPlaneEndpointManager: newControlPlaneEndpointManager(packetConfig.EIPTag, packetConfig.ProjectID, client.DeviceIPs, client.ProjectIPs, i, packetConfig.APIServerPort),
 	}, nil

--- a/packet/config.go
+++ b/packet/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	ProjectID             string  `json:"projectId"`
 	BaseURL               *string `json:"base-url,omitempty"`
 	LoadBalancerConfigMap string  `json:"loadbalancer-configmap"`
+	ConfigMapEnable       bool    `json:"configmap-disable"`
 	Facility              string  `json:"facility,omitempty"`
 	PeerASN               int     `json:"peerASN,omitempty"`
 	LocalASN              int     `json:"localASN,omitempty"`

--- a/packet/loadbalancers.go
+++ b/packet/loadbalancers.go
@@ -427,7 +427,7 @@ func (l *loadBalancers) addService(svc *v1.Service, ips []packngo.IPAddressReser
 			klog.V(2).Infof("failed to update service %s: %v", svcName, err)
 			return fmt.Errorf("failed to update service %s: %v", svcName, err)
 		}
-
+		klog.V(2).Infof("successfully assigned %s update service %s", svcIP, svcName)		
 	}
 	// our default CIDR for each address is 32
 	cidr := 32


### PR DESCRIPTION
This is the initial commit to move to a CCM that we can divert the code path away from `metallb` and ensure that the `status` is correctly updated for "general purpose" Loadbalancers.