### PR TITLE
src IP annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,16 @@ Value for node selector should be a valid Kubernetes label selector (e.g. key1=v
 In addition to enabling BGP and setting ASNs, the Equinix Metal CCM sets Kubernetes annotations on the nodes. It sets the
 following information:
 
-* `packet.com/node.asn` - Node, or local, ASN
-* `packet.com/peer.asns` - Peer ASNs, comma-separated if multiple
-* `packet.com/peer.ips` - Peer IPs, comma-separated if multiple
+* `packet.com/node-asn` - Node, or local, ASN
+* `packet.com/peer-asns` - Peer ASNs, comma-separated if multiple
+* `packet.com/peer-ips` - Peer IPs, comma-separated if multiple
+* `packet.com/src-ip` - Source IP to use
+
 
 These annotation names can be overridden, if you so choose. The settings are as follows:
 
-1. If the environment variables `PACKET_ANNOTATION_LOCAL_ASN`, `PACKET_ANNOTATION_PEER_ASNS`, `PACKET_ANNOTATION_PEER_IPS` are set. Else...
-1. If the config file has files named `annotationLocalASN`, `annotationPeerASNs`, `annotationPeerIPs`. Else...
+1. If the environment variables `PACKET_ANNOTATION_LOCAL_ASN`, `PACKET_ANNOTATION_PEER_ASNS`, `PACKET_ANNOTATION_PEER_IPS`, `PACKET_ANNOTATION_SRC_IP` are set. Else...
+1. If the config file has files named `annotationLocalASN`, `annotationPeerASNs`, `annotationPeerIPs`, `annotationSrcIP`. Else...
 1. Use the above defaults.
 
 ### Load Balancers
@@ -335,7 +337,7 @@ You can run the CCM locally on your laptop or VM, i.e. not in the cluster. This 
 1. Build it for your local platform `make build`
 1. Set the environment variable `CCM_SECRET` to a file with the secret contents as a json, i.e. the content of the secret's `stringData`, e.g. `CCM_SECRET=ccm-secret.yaml`
 1. Set the environment variable `KUBECONFIG` to a kubeconfig file with sufficient access to the cluster, e.g. `KUBECONFIG=mykubeconfig`
-1. Set the environment variable `PACKET_FACILITY_NAME` to the correct facility where the cluster is running, e.g. `PACKET_FACILITY_NAME=EWR1`
+1. Set the environment variable `PACKET_FACILITY_NAME` to the correct facility where the cluster is running, e.g. `PACKET_FACILITY_NAME=ewr1`
 1. If you want to run the loadbalancer, and it is not yet deployed, run `kubectl apply -f deploy/loadbalancer.yaml`
 1. If you want to use a managed Elastic IP for the control plane, create one using the Equinix Metal API or Web UI, tag it uniquely, and set the environment variable `PACKET_EIP_TAG=<tag>`
 1. Run the command, e.g.:

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ const (
 	envVarAnnotationLocalASN     = "PACKET_ANNOTATION_LOCAL_ASN"
 	envVarAnnotationPeerASNs     = "PACKET_ANNOTATION_PEER_ASNS"
 	envVarAnnotationPeerIPs      = "PACKET_ANNOTATION_PEER_IPS"
+	envVarAnnotationSrcIP        = "PACKET_ANNOTATION_SRC_IP"
 	envVarEIPTag                 = "PACKET_EIP_TAG"
 	envVarAPIServerPort          = "PACKET_API_SERVER_PORT"
 	envVarBGPNodeSelector        = "PACKET_BGP_NODE_SELECTOR"
@@ -189,6 +190,11 @@ func getPacketConfig(providerConfig string) (packet.Config, error) {
 	annotationPeerIPs := os.Getenv(envVarAnnotationPeerIPs)
 	if annotationPeerIPs != "" {
 		config.AnnotationPeerIPs = annotationPeerIPs
+	}
+	config.AnnotationSrcIP = packet.DefaultAnnotationSrcIP
+	annotationSrcIP := os.Getenv(envVarAnnotationSrcIP)
+	if annotationSrcIP != "" {
+		config.AnnotationSrcIP = annotationSrcIP
 	}
 
 	if rawConfig.EIPTag != "" {

--- a/packet/cloud.go
+++ b/packet/cloud.go
@@ -70,7 +70,7 @@ func newCloud(packetConfig Config, client *packngo.Client) (cloudprovider.Interf
 		instances:                   i,
 		zones:                       newZones(client, packetConfig.ProjectID),
 		loadBalancer:                newLoadBalancers(client, packetConfig.ProjectID, packetConfig.Facility, packetConfig.LoadBalancerConfigMap, packetConfig.LocalASN, packetConfig.PeerASN),
-		bgp:                         newBGP(client, packetConfig.ProjectID, packetConfig.LocalASN, packetConfig.PeerASN, packetConfig.AnnotationLocalASN, packetConfig.AnnotationPeerASNs, packetConfig.AnnotationPeerIPs, packetConfig.BGPNodeSelector),
+		bgp:                         newBGP(client, packetConfig.ProjectID, packetConfig.LocalASN, packetConfig.PeerASN, packetConfig.AnnotationLocalASN, packetConfig.AnnotationPeerASNs, packetConfig.AnnotationPeerIPs, packetConfig.AnnotationSrcIP, packetConfig.BGPNodeSelector),
 		controlPlaneEndpointManager: newControlPlaneEndpointManager(packetConfig.EIPTag, packetConfig.ProjectID, client.DeviceIPs, client.ProjectIPs, i, packetConfig.APIServerPort),
 	}, nil
 }

--- a/packet/config.go
+++ b/packet/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	AnnotationLocalASN    string  `json:"annotationLocalASN,omitEmpty"`
 	AnnotationPeerASNs    string  `json:"annotationPeerASNs,omitEmpty"`
 	AnnotationPeerIPs     string  `json:"annotationPeerIPs,omitEmpty"`
+	AnnotationSrcIP       string  `json:"annotationSrcIP,omitEmpty"`
 	EIPTag                string  `json:"eipTag,omitEmpty"`
 	APIServerPort         int     `json:"apiServerPort,omitEmpty"`
 	BGPNodeSelector       string  `json:"bgpNodeSelector,omitEmpty"`

--- a/packet/constants.go
+++ b/packet/constants.go
@@ -6,9 +6,10 @@ const (
 	packetIdentifier          = "packet-ccm-auto"
 	packetTag                 = "usage=" + packetIdentifier
 	ccmIPDescription          = "Packet Kubernetes CCM auto-generated for Load Balancer"
-	DefaultAnnotationNodeASN  = "packet.com/node.asn"
-	DefaultAnnotationPeerASNs = "packet.com/peer.asns"
-	DefaultAnnotationPeerIPs  = "packet.com/peer.ips"
+	DefaultAnnotationNodeASN  = "packet.com/node-asn"
+	DefaultAnnotationPeerASNs = "packet.com/peer-asn"
+	DefaultAnnotationPeerIPs  = "packet.com/peer-ip"
+	DefaultAnnotationSrcIP    = "packet.com/src-ip"
 	DefaultLocalASN           = 65000
 	DefaultPeerASN            = 65530
 	DefaultAPIServerPort      = 6443

--- a/packet/eip_controlplane_reconciliation.go
+++ b/packet/eip_controlplane_reconciliation.go
@@ -83,7 +83,7 @@ func (m *controlPlaneEndpointManager) reconcileNodes(ctx context.Context, nodes 
 		m.inProcess = false
 	}()
 	if m.eipTag == "" {
-		return errors.New("elastic ip tag is empty. Nothing to do")
+		return errors.New("control plane loadbalancer elastic ip tag is empty. Nothing to do")
 	}
 	ipList, _, err := m.ipResSvr.List(m.projectID, &packngo.ListOptions{
 		Includes: []string{"assignments"},


### PR DESCRIPTION
We already set annotations for peer ASN, local ASN, and peer IPs. This adds an annotation for the src IP, so you know which IP to use to source the peering request.

It also:

* standardizes the default annotation names
* fixes an error message to make it clearer