### PR TITLE
Fix boolean logic in auth token debug info

### DIFF
--- a/packet/config.go
+++ b/packet/config.go
@@ -25,7 +25,7 @@ type Config struct {
 // and masks sensitive data
 func (c Config) Strings() []string {
 	ret := []string{}
-	if c.AuthToken == "" {
+	if c.AuthToken != "" {
 		ret = append(ret, "authToken: '<masked>'")
 	} else {
 		ret = append(ret, "authToken: ''")


### PR DESCRIPTION
We want to print `<masked>` when the auth token string is NOT empty.

cc: @deitch 