### PR TITLE
add kube-vip loadbalancer option

### DIFF
--- a/packet/loadbalancers.go
+++ b/packet/loadbalancers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/packethost/packet-ccm/packet/loadbalancers"
 	"github.com/packethost/packet-ccm/packet/loadbalancers/empty"
+	"github.com/packethost/packet-ccm/packet/loadbalancers/kubevip"
 	"github.com/packethost/packet-ccm/packet/loadbalancers/metallb"
 	"github.com/packethost/packngo"
 
@@ -65,6 +66,9 @@ func (l *loadBalancers) init(k8sclient kubernetes.Interface) error {
 	config := u.Path
 	var impl loadbalancers.LB
 	switch u.Scheme {
+	case "kuve-vip":
+		klog.V(2).Info("loadbalancer implementation enabled: kube-vip")
+		impl = kubevip.NewLB(k8sclient, config)
 	case "metallb":
 		klog.V(2).Info("loadbalancer implementation enabled: metallb")
 		impl = metallb.NewLB(k8sclient, config)

--- a/packet/loadbalancers/kubevip/kubevip.go
+++ b/packet/loadbalancers/kubevip/kubevip.go
@@ -1,0 +1,43 @@
+// kubevip loadbalancer that does nothing, but exists to enable bgp functionality
+package kubevip
+
+import (
+	"context"
+
+	"github.com/packethost/packet-ccm/packet/loadbalancers"
+	"k8s.io/client-go/kubernetes"
+)
+
+type LB struct {
+}
+
+func NewLB(k8sclient kubernetes.Interface, config string) *LB {
+	return &LB{}
+}
+
+func (l *LB) AddService(ctx context.Context, svc, ip string) error {
+	return nil
+}
+
+func (l *LB) RemoveService(ctx context.Context, ip string) error {
+	return nil
+}
+
+func (l *LB) SyncServices(ctx context.Context, ips map[string]bool) error {
+	return nil
+}
+
+// AddNode add a node with the provided name, srcIP, and bgp information
+func (l *LB) AddNode(ctx context.Context, nodeName string, localASN, peerASN int, srcIP string, peers ...string) error {
+	return nil
+}
+
+// RemoveNode remove a node with the provided name
+func (l *LB) RemoveNode(ctx context.Context, nodeName string) error {
+	return nil
+}
+
+// SyncNodes ensure that the list of nodes is only those with the matched names
+func (l *LB) SyncNodes(ctx context.Context, nodes map[string]loadbalancers.Node) error {
+	return nil
+}


### PR DESCRIPTION
This needs to be completed as follows.

* link to correct kube-vip documentation for configuring and consuming annotations, and using service IPs
* add any missing kube-vip support pieces
* ensure that kube-vip works correctly

